### PR TITLE
Fix resolveMPI for nodes with comm != 1

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -865,7 +865,7 @@ resolveMPI <- local({
                              inherits = FALSE)
           resolveMPI <- function(future) {
             node <- future$workers[[future$node]]
-            mpi.iprobe(source = node$rank, tag = mpi.any.tag())
+            mpi.iprobe(source = node$rank, comm = node$comm, tag = mpi.any.tag())
           }
         }
       }


### PR DESCRIPTION
The current code of resolve MPI uses the default value of 1 for the
communicator when calling `mpi.iprobe`. This can result in MPI aborting the
process due to the use of an invalid communicator (the following output was
encountered when generating futures on a MPI cluster spawned via slurm's
`salloc`.)

```
[mcsbx02:2188] *** An error occurred in MPI_Iprobe
[mcsbx02:2188] *** reported by process [1863778305,140728898420736]
[mcsbx02:2188] *** on communicator MPI_COMM_NULL
[mcsbx02:2188] *** MPI_ERR_COMM: invalid communicator
[mcsbx02:2188] *** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
[mcsbx02:2188] ***    and potentially your MPI job)
```

To fix this we simply pass the `node$comm` when making the call
to `mpi.iprobe`.