### PR TITLE
Update `expr` after calling `getGlobalsAndPackages()`

### DIFF
--- a/R/MulticoreFuture-class.R
+++ b/R/MulticoreFuture-class.R
@@ -18,7 +18,8 @@ MulticoreFuture <- function(expr = NULL, envir = parent.frame(), substitute = FA
   ## Global objects
   assignToTarget <- (is.list(globals) || inherits(globals, "Globals"))
   gp <- getGlobalsAndPackages(expr, envir = envir, tweak = tweakExpression, globals = globals)
-
+  expr <- gp$expr
+  
   ## Assign?
    if (length(gp) > 0L && (lazy || assignToTarget)) {
     target <- new.env(parent = envir)

--- a/R/UniprocessFuture-class.R
+++ b/R/UniprocessFuture-class.R
@@ -23,6 +23,7 @@ UniprocessFuture <- function(expr = NULL, envir = parent.frame(), substitute = F
   ## Global objects?
   gp <- getGlobalsAndPackages(expr, envir = envir, tweak = tweakExpression, globals = globals)
   globals <- gp$globals
+  expr <- gp$expr
 
   ## Record packages?
   if (length(packages) > 0 || (length(gp$packages) > 0 && lazy)) {


### PR DESCRIPTION
I belive that both the Uniprocess and Multicore future classes should update `expr` after calling `getGlobalsAndPackages()`, since that function can modify the `expr` when there are `...`.

The Multisession future already updates `expr`

Here is an ugly contrived example, but something like this came up with furrr. The example now works with this PR

``` r
library(future)
#> Warning: package 'future' was built under R version 4.0.2
library(rlang)
#> Warning: package 'rlang' was built under R version 4.0.2

expr <- expr({
  fn <- function() {
    list(...) # <- these dots will be passed elsewhere
  }
  
  fn()
})

future_wrapper <- function(expr, ...) {
  globals <- globals::globalsByName("...", envir = environment())
  globals <- future::as.FutureGlobals(globals)
  
  future::future(
    expr, 
    substitute = FALSE, 
    envir = parent.frame(), 
    globals = globals
  )
}

plan(sequential)
future::value(future_wrapper(expr, x = 1))
#> Error in fn(): '...' used in an incorrect context

plan(multisession)
future::value(future_wrapper(expr, x = 1))
#> $x
#> [1] 1
```

<sup>Created on 2020-08-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>